### PR TITLE
fix(cucumber-runner): fix boolean datatable transformation.

### DIFF
--- a/cucumber/cucumber-runner/src/gherkin/datatables/transform-table-value.ts
+++ b/cucumber/cucumber-runner/src/gherkin/datatables/transform-table-value.ts
@@ -10,7 +10,7 @@ export function transformTableValue(data: TableCell | string) {
   }
 
   if (value === "false" || value === "true") {
-    return Boolean(value);
+    return value === "true";
   }
   return value;
 }


### PR DESCRIPTION
Hello

Thank for your work.

However I could notice that there was a small error in the transformation of a boolean in a datatable.
I therefore propose this small correction.

Indeed the Boolean function returns true for a string if it is not empty.

[source](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)