### PR TITLE
Move datatable tranfom into Table class.

### DIFF
--- a/cucumber/cucumber-runner/src/gherkin/datatables/list-table.ts
+++ b/cucumber/cucumber-runner/src/gherkin/datatables/list-table.ts
@@ -1,21 +1,20 @@
 import { ParsedDataTable } from "./datatable";
 import { CompiledDataTable } from "./table-type";
-import { TableValue } from "./table-value";
 interface IListTable {
   /**
    * Get an array of table values corresponding
    * to an entire row of the Datatable
    * @param rowIndex The index of the row to retrieve
    */
-  get(rowIndex: number): TableValue[];
+  get(rowIndex: number): string[];
   /**
    * Get a value corresponding to an entry of
    * a row.
    * @param rowIndex The index of the row to retrieve
    * @param columnIndex The column in the selected row to retrieve a cell from
    */
-  get(rowIndex: number, columnIndex: number): TableValue;
-  get(rowIndex: number, columnIndex?: number): TableValue[] | TableValue;
+  get(rowIndex: number, columnIndex: number): string;
+  get(rowIndex: number, columnIndex?: number): string[] | string;
 }
 /**
  * Datatable transformer that converts
@@ -30,7 +29,7 @@ interface IListTable {
  *
  */
 export class ListTable extends ParsedDataTable implements IListTable {
-  readonly rows: readonly TableValue[][];
+  readonly rows: readonly string[][];
   constructor(protected raw: CompiledDataTable) {
     super();
     this.rows = raw;
@@ -41,7 +40,7 @@ export class ListTable extends ParsedDataTable implements IListTable {
     if (!row) {
       throw new Error(`No table row found at index ${rowIndex}`);
     }
-    if (columnIndex != undefined && columnIndex != null) {
+    if (columnIndex) {
       const cell = row.at(columnIndex);
       if (!cell) {
         throw new Error(`No table cell found at index ${rowIndex}, ${columnIndex}`);

--- a/cucumber/cucumber-runner/src/gherkin/datatables/mtable.ts
+++ b/cucumber/cucumber-runner/src/gherkin/datatables/mtable.ts
@@ -1,3 +1,4 @@
+import { transformTableValue } from './transform-table-value';
 import { ParsedDataTable } from "./datatable";
 import { CompiledDataTable } from "./table-type";
 import { TableValue } from "./table-value";
@@ -34,6 +35,17 @@ interface IMTable {
    */
   get(verticalHeader: string, horizontalHeader: string): TableValue;
   get(verticalHeader: string, horizontalHeader?: string): TableValue;
+  /**
+   * @param header The column title to collect
+   * @param raw Recover raw data without type transformation.
+   */
+  get(header: string, raw?: boolean): TableValue;
+  /**
+   * @param header The column title to collect
+   * @param horizontalHeader The cells row-index of that column to retrieve.
+   * @param raw Recover raw data without type transformation.
+   */
+  get(header: string, horizontalHeader?: string, raw?: boolean): TableValue;
 }
 
 /**
@@ -62,7 +74,7 @@ export class MTable extends ParsedDataTable implements IMTable {
     this.vheaders = raw.slice(1, raw.length).map(([title]) => title as string);
     const row = raw.at(0) ?? [];
     this.hheaders = row.slice(1, row.length).map((it) => it as string) ?? [];
-    this.rows = raw.slice(1, raw.length).map((row) => row.slice(1, row.length));
+    this.rows = raw.slice(1, raw.length).map((row) => row.slice(1, row.length).map(transformTableValue));
     const mapHeaders = (collection: HeaderMapping) => (header: string, idx: number) => {
       collection[header] = idx;
     };
@@ -70,21 +82,25 @@ export class MTable extends ParsedDataTable implements IMTable {
     this.hheaders.forEach(mapHeaders(this.hheaderMappings));
   }
 
-  get = (verticalHeader: string, horizontalHeader?: string) => {
+  get = (verticalHeader: string, horizontalHeaderOrRaw?: string | boolean, raw?: boolean) => {
+    let getRaw = raw;
+    if (typeof horizontalHeaderOrRaw === 'boolean') {
+      getRaw = horizontalHeaderOrRaw;
+    }
+    const rows = getRaw ? this.raw.slice(1, this.raw.length).map((row) => row.slice(1, row.length)) : this.rows
     const vIndex = this.vheaderMappings[verticalHeader];
-    const row = this.rows[vIndex];
-    if (horizontalHeader) {
-      const hIndex = this.hheaderMappings[horizontalHeader];
-      const cell = row[hIndex];
-      return cell;
+    const row = rows[vIndex];
+    if (typeof horizontalHeaderOrRaw === 'string') {
+      const hIndex = this.hheaderMappings[horizontalHeaderOrRaw];
+      return  row[hIndex];
     }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return row as any;
   };
 
-  col = (horizontalHeader: string) => {
+  col = (horizontalHeader: string, raw?: boolean) => {
+    const rows = raw ? this.raw.slice(1, this.raw.length).map((row) => row.slice(1, row.length)) : this.rows
     const hIndex = this.hheaderMappings[horizontalHeader];
-    const col = this.rows.map((it) => it.at(hIndex)) as TableValue[];
-    return col;
+    return  rows.map((it) => it.at(hIndex)) as TableValue[];
   };
 }

--- a/cucumber/cucumber-runner/src/gherkin/datatables/table-type.ts
+++ b/cucumber/cucumber-runner/src/gherkin/datatables/table-type.ts
@@ -1,8 +1,6 @@
 import { DataTable } from "@cucumber/messages";
 import { ParsedDataTable } from "./datatable";
-import { TableValue } from "./table-value";
-import { transformTableValue } from "./transform-table-value";
-export type CompiledDataTable = TableValue[][];
+export type CompiledDataTable = string[][];
 
 export type TableType<T extends ParsedDataTable> = {
   new (table: CompiledDataTable): T;
@@ -12,5 +10,5 @@ export function compileDatatable(table?: DataTable): CompiledDataTable | undefin
   if (!table) {
     return undefined;
   }
-  return table.rows.map(({ cells }) => cells.map(transformTableValue));
+  return table.rows.map(({ cells }) => cells.map(cell => cell.value));
 }

--- a/cucumber/cucumber-runner/src/gherkin/gherkin-examples.ts
+++ b/cucumber/cucumber-runner/src/gherkin/gherkin-examples.ts
@@ -1,6 +1,4 @@
 import { Background, Scenario } from "@cucumber/messages";
-import type { TableValue } from "./datatables/table-value";
-import { transformTableValue } from "./datatables/transform-table-value";
 import { GherkinNode } from "./gherkin-node";
 import { GherkinScenario } from "./gherkin-scenario";
 import type { Examples } from "./parser.types";
@@ -14,7 +12,7 @@ export class GherkinExamples extends GherkinNode {
   readonly tags: string[] = [];
 
   readonly headers: string[];
-  readonly rows: TableValue[][];
+  readonly rows: string[][];
   readonly scenarios: GherkinScenario[] = [];
 
   constructor(
@@ -26,9 +24,7 @@ export class GherkinExamples extends GherkinNode {
     super();
     this.takeTags([...message.examples.tags], ...inheritedTags);
     this.headers = this.message.examples.tableHeader?.cells.map((it) => it.value) ?? [];
-    this.rows = this.message.examples.tableBody.map((it) =>
-      it.cells.map((cell) => transformTableValue(cell.value))
-    );
+    this.rows = this.message.examples.tableBody.map(({ cells }) => cells.map(({ value }) => value));
     for (const row of this.rows) {
       const scenarioExample = row.map((it, idx) => ({
         key: this.headers[idx],

--- a/cucumber/cucumber-runner/src/gherkin/gherkin-scenario.ts
+++ b/cucumber/cucumber-runner/src/gherkin/gherkin-scenario.ts
@@ -8,7 +8,6 @@ import { Background, DocString, StepKeywordType } from "@cucumber/messages";
 import { getTableOrDocstring } from "./datatables/get-table-or-docstring";
 import { compileDatatable, type CompiledDataTable } from "./datatables/table-type";
 import type { Modifiers } from "./types";
-import type { TableValue } from "./datatables/table-value";
 import { Docstring } from "./doc-string";
 import crypto from "crypto";
 export type ScenarioMessage = { scenario: Scenario; backgrounds?: { background: Background }[] };
@@ -21,7 +20,7 @@ export class GherkinScenario extends GherkinNode {
     readonly message: ScenarioMessage,
     readonly stepCache: StepCache,
     inheritedTags?: string[],
-    readonly example?: { readonly key: string; readonly value: TableValue }[],
+    readonly example?: { readonly key: string; readonly value: string }[],
     private exampleIdx?: number
   ) {
     super();
@@ -59,7 +58,7 @@ export class GherkinScenario extends GherkinNode {
 
   private loadFromGherkin(
     message: ScenarioMessage,
-    example: { readonly key: string; readonly value: TableValue }[] | undefined
+    example: { readonly key: string; readonly value: string }[] | undefined
   ) {
     const backgrounds = message.backgrounds ?? [];
     for (const background of backgrounds) {
@@ -128,12 +127,12 @@ export class GherkinScenario extends GherkinNode {
 
 function interpolateStepText(
   text: string,
-  example: { readonly key: string; readonly value: TableValue }[] | undefined
+  example: { readonly key: string; readonly value: string }[] | undefined
 ) {
   let realText = text;
   if (example) {
     for (const { key, value } of example) {
-      realText = realText.replace(`<${key}>`, `${value}`);
+      realText = realText.replace(`<${key}>`, value);
     }
   }
   return realText;
@@ -141,7 +140,7 @@ function interpolateStepText(
 
 function interpolateStepDatatable(
   table?: CompiledDataTable,
-  example?: { readonly key: string; readonly value: TableValue }[]
+  example?: { readonly key: string; readonly value: string }[]
 ) {
   if (!table) {
     return undefined;


### PR DESCRIPTION
Hello,

I think that when generating the datatable, the raw data retrieved from the gerkin file should not be transformed.

For this I propose to move the transformation logic directly into the datatable classes.

Here I only dealt with HTable.

Thanks to this, it is now possible to retrieve the raw data from the HTable.

If you are ok with this change I could take care of the VTable, MTable and ListTable.