### PR TITLE
fix(cucumber-runner): fix Number datatable transformation.

### DIFF
--- a/cucumber/cucumber-runner/src/gherkin/datatables/transform-table-value.ts
+++ b/cucumber/cucumber-runner/src/gherkin/datatables/transform-table-value.ts
@@ -4,7 +4,7 @@ export function transformTableValue(value: string): TableValue;
 export function transformTableValue(cell: TableCell): TableValue;
 export function transformTableValue(data: TableCell | string) {
   const value = typeof data === "string" ? data : data.value;
-  const asNum = Number(value);
+  const asNum = parseFloat(value);
   if (!isNaN(asNum)) {
     return asNum;
   }


### PR DESCRIPTION
Hello,

small change when converting a string to a number.

Use of the `parseFloat` function instead of `Number` because `Number('') return 0` while `parseFloat('') return NaN`