### PR TITLE
fix: primitive returns NaN for strings like 'ab2dc'

### DIFF
--- a/.changeset/healthy-trains-guess.md
+++ b/.changeset/healthy-trains-guess.md
@@ -1,0 +1,7 @@
+---
+"@autometa/cucumber-expressions": patch
+"@autometa/scopes": patch
+"@autometa/app": patch
+---
+
+Fixes strings like 'abc2bd' being parsed as NaN in `primitive` expression type. Not supports comma and decimal delimters (EU, US respectively

--- a/packages/app/src/fixtures.typings.ts
+++ b/packages/app/src/fixtures.typings.ts
@@ -1,7 +1,93 @@
 /* eslint-disable @typescript-eslint/no-empty-interface */
 
-export interface World {}
+/**
+ * Basic Key Value store for managing state across Step Definitions. A unique copy of this object
+ * is shared between all steps and hooks in a given running Scenario, however it is not possible
+ * to interact with state outside of that Scenarios life cycle. That is to say, while the World
+ * is shared between steps, it is unique across tests.
+ * 
+ * To extend the worlds vocabulary, you can declare properties on the World. These do not need
+ * to be defined at run time. Instead they will be filled in as they are produced by steps.
+ * 
+ * To declare World properties, you can simply declare an uninitialized property. Depending
+ * on your `tsconfig.json` settings you can do so with one of the three following syntaxes:
+ * 
+ * ```typescript
+ * @Fixture
+ * export class World {
+ *  [key: string]: unknown;
+ *  
+ *  declare foo: number
+ * 
+ *  foo: number
+ * 
+ *  foo!: number
+ * }
+ * 
+ * The World is automatically injected into the {@link App} object, and can be accessed via
+ * the last (or only) argument of a step definition callback.
+ * 
+ * ```ts
+ * Given('I have {int} cats', (cats: number, app: App) => {
+ *    app.world.cats = cats
+ * })
+ * 
+ * // using destructuring
+ * Given('I have {int} cats', ({world}: App) => {
+ *   world.cats = cats
+ * })
+ * ```
+ */
+export interface World {
+  [key: string]: unknown;
+}
+
+/**
+ * The App object is the primary interface for interacting with the running application. It is
+ * composed of `Fixtures` which are classes decorated with the `@Fixture` decorator. Fixtures
+ * are automatically instantiated and injected into the App object. The App object is then
+ * injected into the last (or only) argument of a step definition callback.
+ * 
+ * i.e.
+ * 
+ * ```ts
+ * // single argument
+ * Given('I have 5 cats', (app: App) => {})
+ * // Cucumber Expression
+ * Given('I have {int} cats', (cats: number, app: App) => {})
+ * // Data table
+ * Given('I have {int} cats', (cats: number, table: HTable app: App) => {}, HTable)
+ * ```
+ * 
+ * **Note**: The type annotations here are optional. Non-custom Cucumber Expression types
+ * will be automatically inferred by their expression template. Custom types will need to
+ * be added via declaration file (see docs)
+ * 
+ * The App is unique across all tests, and is shared between all steps and hooks within a test.
+ * If you have any Fixture classes defined, you can add them as constructor parameters of the App
+ * to make them available to step Definitions (Fixtures can also be accessed as properties from other Fixtures if not defined here);
+ * 
+ * ```ts
+ * \@\Fixture
+ * export class World {}
+ * 
+ * 
+ * \@\Fixture
+ * export class Fixture1 {}
+ * 
+ * \@\Fixture
+ * export class Fixture2 {
+ *  constructor(readonly fixture1: Fixture1, readonly world: World) {}
+ * }
+ * 
+ * \@\AppType(World)
+ * export class App {
+ *   constructor(readonly fixture1: Fixture1, readonly fixture2: Fixture2) {}
+ * }
+ * ```
+ */
 export interface App {
   readonly id: string;
   world: World;
 }
+

--- a/packages/cucumber-expressions/src/default.parameters.spec.ts
+++ b/packages/cucumber-expressions/src/default.parameters.spec.ts
@@ -11,7 +11,7 @@ import {
   PrimitiveParam
 } from "./default.parameters";
 import { AssertDefined } from "@autometa/asserters";
-vi.setSystemTime('2021-01-01T00:00:00.000Z')
+vi.setSystemTime("2021-01-01T00:00:00.000Z");
 Argument.prototype.getValue = function (thisObj: unknown) {
   const groupValues = this.group
     ? this.group.value
@@ -20,6 +20,7 @@ Argument.prototype.getValue = function (thisObj: unknown) {
     : null;
   return this.parameterType.transform(thisObj, groupValues);
 };
+
 describe("Default Parameters", () => {
   describe("Number Parameter", () => {
     it("should match a number", () => {
@@ -73,37 +74,183 @@ describe("Default Parameters", () => {
       expect(args?.length).toBe(1);
       expect(args?.[0].getValue(null)).toBe(true);
     });
-    it("should match a positive number primitive", () => {
-      const registry = new ParameterTypeRegistry();
-      const { name, regexpPattern, transform } = PrimitiveParam;
-      const param = new ParameterType(name, regexpPattern, null, transform);
-      registry.defineParameterType(param);
-      const expression = new CucumberExpression(
-        "I have {primitive} cukes in my belly now",
-        registry
-      );
-      const args = expression.match("I have 7 cukes in my belly now");
-      AssertDefined(args);
-      const [arg] = args;
-      expect(args).toBeDefined();
-      expect(args?.length).toBe(1);
-      const value = arg.getValue(arg);
-      expect(value).toBe(7);
-    });
 
-    it("should match a negative number primitive", () => {
-      const registry = new ParameterTypeRegistry();
-      const { name, regexpPattern, transform } = PrimitiveParam;
-      const param = new ParameterType(name, regexpPattern, null, transform);
-      registry.defineParameterType(param);
-      const expression = new CucumberExpression(
-        "I have {primitive} cukes in my belly now",
-        registry
-      );
-      const args = expression.match("I have -7 cukes in my belly now");
-      expect(args).toBeDefined();
-      expect(args?.length).toBe(1);
-      expect(args?.[0].getValue(null)).toBe(-7);
+    describe("number primitive", () => {
+      it("should match a positive number primitive", () => {
+        const registry = new ParameterTypeRegistry();
+        const { name, regexpPattern, transform } = PrimitiveParam;
+        const param = new ParameterType(name, regexpPattern, null, transform);
+        registry.defineParameterType(param);
+        const expression = new CucumberExpression(
+          "I have {primitive} cukes in my belly now",
+          registry
+        );
+        const args = expression.match("I have 7 cukes in my belly now");
+        AssertDefined(args);
+        const [arg] = args;
+        expect(args).toBeDefined();
+        expect(args?.length).toBe(1);
+        const value = arg.getValue(arg);
+        expect(value).toBe(7);
+      });
+      it("should match a positive integer primitive with a comma delimiter", () => {
+        const registry = new ParameterTypeRegistry();
+        const { name, regexpPattern, transform } = PrimitiveParam;
+        const param = new ParameterType(name, regexpPattern , null, transform);
+        registry.defineParameterType(param);
+        const expression = new CucumberExpression(
+          "I have {primitive} cukes in my belly now",
+          registry
+        );
+        const args = expression.match("I have 7,000 cukes in my belly now");
+        AssertDefined(args);
+        const [arg] = args;
+        expect(args).toBeDefined();
+        expect(args?.length).toBe(1);
+        const value = arg.getValue(arg);
+        expect(value).toBe(7000);
+      });
+
+      it("should match a negative integer primitive", () => {
+        const registry = new ParameterTypeRegistry();
+        const { name, regexpPattern, transform } = PrimitiveParam;
+        const param = new ParameterType(name, regexpPattern, null, transform);
+        registry.defineParameterType(param);
+        const expression = new CucumberExpression(
+          "I have {primitive} cukes in my belly now",
+          registry
+        );
+        const args = expression.match("I have -7 cukes in my belly now");
+        AssertDefined(args);
+        const [arg] = args;
+        expect(args).toBeDefined();
+        expect(args?.length).toBe(1);
+        const value = arg.getValue(arg);
+        expect(value).toBe(-7);
+      });
+
+      it("should match a negative integer primitive with a comma delimiter", () => {
+        const registry = new ParameterTypeRegistry();
+        const { name, regexpPattern, transform } = PrimitiveParam;
+        const param = new ParameterType(name, regexpPattern, null, transform);
+        registry.defineParameterType(param);
+        const expression = new CucumberExpression(
+          "I have {primitive} cukes in my belly now",
+          registry
+        );
+        const args = expression.match("I have -7,000 cukes in my belly now");
+        AssertDefined(args);
+        const [arg] = args;
+        expect(args).toBeDefined();
+        expect(args?.length).toBe(1);
+        const value = arg.getValue(arg);
+        expect(value).toBe(-7000);
+      });
+
+      it("should match a positive float primitive", () => {
+        const registry = new ParameterTypeRegistry();
+        const { name, regexpPattern, transform } = PrimitiveParam;
+        const param = new ParameterType(name, regexpPattern, null, transform);
+        registry.defineParameterType(param);
+        const expression = new CucumberExpression(
+          "I have {primitive} cukes in my belly now",
+          registry
+        );
+        const args = expression.match("I have 7.5 cukes in my belly now");
+        AssertDefined(args);
+        const [arg] = args;
+        expect(args).toBeDefined();
+        expect(args?.length).toBe(1);
+        const value = arg.getValue(arg);
+        expect(value).toBe(7.5);
+      });
+
+      it("should match a negative float primitive", () => {
+        const registry = new ParameterTypeRegistry();
+        const { name, regexpPattern, transform } = PrimitiveParam;
+        const param = new ParameterType(name, regexpPattern, null, transform);
+        registry.defineParameterType(param);
+        const expression = new CucumberExpression(
+          "I have {primitive} cukes in my belly now",
+          registry
+        );
+        const args = expression.match("I have -7.5 cukes in my belly now");
+        AssertDefined(args);
+        const [arg] = args;
+        expect(args).toBeDefined();
+        expect(args?.length).toBe(1);
+        const value = arg.getValue(arg);
+        expect(value).toBe(-7.5);
+      });
+
+      it("should match a positive float primitive with a comma delimiter", () => {
+        const registry = new ParameterTypeRegistry();
+        const { name, regexpPattern, transform } = PrimitiveParam;
+        const param = new ParameterType(name, regexpPattern, null, transform);
+        registry.defineParameterType(param);
+        const expression = new CucumberExpression(
+          "I have {primitive} cukes in my belly now",
+          registry
+        );
+        const args = expression.match("I have 7,000.5 cukes in my belly now");
+        AssertDefined(args);
+        const [arg] = args;
+        expect(args).toBeDefined();
+        expect(args?.length).toBe(1);
+        const value = arg.getValue(arg);
+        expect(value).toBe(7000.5);
+      });
+
+      it("should match a negative float primitive with a comma delimiter", () => {
+        const registry = new ParameterTypeRegistry();
+        const { name, regexpPattern, transform } = PrimitiveParam;
+        const param = new ParameterType(name, regexpPattern, null, transform);
+        registry.defineParameterType(param);
+        const expression = new CucumberExpression(
+          "I have {primitive} cukes in my belly now",
+          registry
+        );
+        const args = expression.match("I have -7,000.5 cukes in my belly now");
+        AssertDefined(args);
+        const [arg] = args;
+        expect(args).toBeDefined();
+        expect(args?.length).toBe(1);
+        const value = arg.getValue(arg);
+        expect(value).toBe(-7000.5);
+      });
+
+      it("should match a positive float primitive with a comma delimiter and no decimal", () => {
+        const registry = new ParameterTypeRegistry();
+        const { name, regexpPattern, transform } = PrimitiveParam;
+        const param = new ParameterType(name, regexpPattern, null, transform);
+        registry.defineParameterType(param);
+        const expression = new CucumberExpression(
+          "I have {primitive} cukes in my belly now",
+          registry
+        );
+        const args = expression.match("I have 7,000 cukes in my belly now");
+        AssertDefined(args);
+        const [arg] = args;
+        expect(args).toBeDefined();
+        expect(args?.length).toBe(1);
+        const value = arg.getValue(arg);
+        expect(value).toBe(7000);
+      });
+      
+    //   it('should match a positive float with a dot delimiter and comma decimal', ()=>{
+    //     const registry = new ParameterTypeRegistry();
+    //     const { name, regexpPattern, transform } = PrimitiveParam;
+    //     const param = new ParameterType(name, regexpPattern, null, transform);
+    //     registry.defineParameterType(param);
+    //     const expression = new CucumberExpression('I have {primitive} cukes in my belly now', registry);
+    //     const args = expression.match('I have 7.000,5 cukes in my belly now');
+    //     AssertDefined(args);
+    //     const [arg] = args;
+    //     expect(args).toBeDefined();
+    //     expect(args?.length).toBe(1);
+    //     const value = arg.getValue(arg);
+    //     expect(value).toBe(7000.5);
+    //   })
     });
 
     it("should match a null primitive", () => {

--- a/packages/scopes/src/scopes.ts
+++ b/packages/scopes/src/scopes.ts
@@ -17,10 +17,161 @@ import { AfterHook, BeforeHook, SetupHook, TeardownHook } from "./hook";
 
 export interface Scopes {
   Global: GlobalScope;
-
+  /**
+   * Executes a gherkin `.feature` file. Assembles Tests
+   * using the Cucumber file and globally defined Step Definitions.
+   * 
+   * ``ts
+   * // using relative path
+   * import { Feature } from '@autometa/runner'
+   * 
+   * Feature('../features/my-feature.feature')
+   * ```
+   * 
+   * Steps will be automatically assembled from Globally defined Step Definitions,
+   * if a step definition root and app root are defined.
+   * 
+   * ```ts
+   * import { defineConfig } from '@autometa/runner'
+   * 
+   * defineConfig({
+   *  ...
+   *  roots: {
+   *    steps: ['./test/steps'],
+   *    app: ['./app'],
+   *  },
+   * }
+   * ```
+   * 
+   * Global steps are defined in standard Cucumber stle.
+   * ```ts
+   * // ./test/steps/my-steps.ts
+   * import { Given, When, Then } from '@autometa/runner'
+   * 
+   * Given('I have a step', () => {})
+   * When('I do something', () => {})
+   * Then('I expect something', () => {})
+   * ```
+   * @param filepath The absolute, relative, or 'feature root' path to the `.feature` file.
+   */
   Feature(filepath: string): FeatureScope;
+  /**
+   * Executes a gherkin `.feature` file. Assembles Tests
+   * using the Cucumber file and globally defined Step Definitions.
+   * Accepts a timeout in milliseconds which will be applied to
+   * all tests within the feature.
+   * 
+   * ``ts
+   * // using relative path
+   * import { Feature } from '@autometa/runner'
+   *  // 10 second timeout
+   * Feature('../features/my-feature.feature', 10_000)
+   * ```
+   * 
+   * Steps will be automatically assembled from Globally defined Step Definitions,
+   * if a step definition root and app root are defined.
+   * 
+   * ```ts
+   * import { defineConfig } from '@autometa/runner'
+   * 
+   * defineConfig({
+   *  ...
+   *  roots: {
+   *   steps: ['./test/steps'],
+   *   app: ['./app'],
+   *  },
+   * }
+   * ```
+   * 
+   * Global steps are defined in standard Cucumber stle.
+   * 
+   * ```ts
+   * // ./test/steps/my-steps.ts
+   * import { Given, When, Then } from '@autometa/runner'
+   * 
+   * Given('I have a step', () => {})
+   * When('I do something', () => {})
+   * Then('I expect something', () => {})
+   * ```
+   * @param filepath The absolute, relative, or 'feature root' path to the `.feature` file.
+   * @param timeout The timeout in milliseconds to apply to all tests within the feature.
+   */
   Feature(filepath: string, timeout: number): FeatureScope;
+  /**
+   * Executes a gherkin `.feature` file. Assembles Tests
+   * using the Cucumber file and globally defined Step Definitions.
+   * Accepts a timeout as a `TestTimeout` which is a tuple of `[durationNumber, 'ms' | 's' | 'm' | 'h']`
+   * which will be applied to all tests within the feature.
+   * 
+   * i.e. `[10, 's']` is a 10 second timeout. `[1, 'm']` is a 1 minute timeout.
+   * 
+   * ``ts
+   * // using relative path
+   * import { Feature } from '@autometa/runner'
+   * 
+   * // 10 second timeout
+   * Feature('../features/my-feature.feature', [10, 's'])
+   * ```
+   * 
+   * Steps will be automatically assembled from Globally defined Step Definitions,
+   * if a step definition root and app root are defined.
+   * 
+   * ```ts
+   * import { defineConfig } from '@autometa/runner'
+   * 
+   * defineConfig({
+   *  ...
+   *  roots: {
+   *   steps: ['./test/steps'],
+   *   app: ['./app'],
+   *  },
+   * };
+   * 
+   * ```
+   * 
+   * @param filepath 
+   * @param timeout 
+   */
   Feature(filepath: string, timeout: TestTimeout): FeatureScope;
+  /**
+   * Executes a gherkin `.feature` file. Assembles Tests
+   * using the Cucumber file and optionally locally defined steps,
+   * mixed with optionally globally defined Step Definitions.
+   * 
+   * ```ts
+   * import { Feature } from '@autometa/runner'
+   * 
+   * Feature('My Feature', () => {
+   *   Given('I have a step', () => {})
+   *   When('I do something', () => {})
+   *   Then('I expect something', () => {})
+   * })
+   * ```ts
+   * 
+   * If defined in the Gherkin, it will also use any Globally defined Step Definitions which match,
+   * if none is defined locally. If a Step Definition is defined both globally and locally,
+   * the most local definition will be used. This applies to sub-scopes like Scenarios and Rules
+   * also.
+   * 
+   * ```ts
+   * import { Feature } from '@autometa/runner'
+   * 
+   * Feature('My Feature', () => {
+   *  Given('I have a step', () => {})
+   *  When('I do something', () => {})
+   *  Then('I expect something', () => {})
+   * 
+   *  Scenario('My Scenario', () => {
+   *    Given('I have a step', () => {})
+   *  })
+   * 
+   *  Rule('My Rule', () => {
+   *   Given('I have a step', () => {})
+   *  })
+   * 
+   * @param testDefinition 
+   * @param filepath 
+   */
   Feature(testDefinition: FeatureAction, filepath: string): FeatureScope;
   Feature(
     testDefinition: FeatureAction,
@@ -32,6 +183,10 @@ export interface Scopes {
     filepath: string,
     timeout: SizedTimeout
   ): FeatureScope;
+  /**
+   * FPPPPPPPPPPP
+   * @param args 
+   */
   Feature(...args: (FeatureAction | string | TestTimeout)[]): FeatureScope;
 
   Scenario(title: string, action: ScenarioAction): ScenarioScope;


### PR DESCRIPTION
Added support for comma and decimal separated numbers, e.g,

1,000
1,000.50
1.000,50

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **What is the motivation for this change?**



* **Other information**: