### PR TITLE
feat(http): allow client config options to be built with

### DIFF
--- a/.changeset/weak-ladybugs-buy.md
+++ b/.changeset/weak-ladybugs-buy.md
@@ -1,0 +1,5 @@
+---
+"@autometa/http": patch
+---
+
+feat(http): allow client options to be created with `sharedOptions`

--- a/documentation/website/docs/cucumber/test_runner/http-client.mdx
+++ b/documentation/website/docs/cucumber/test_runner/http-client.mdx
@@ -14,8 +14,9 @@ parameter for whatever fixture or App is consuming it.
 
 ```ts
 @Fixture
+@Constructor(HTTP)
 export class MyClient {
-  constructor(private http: Http) {}
+  constructor(private http: HTTP) {}
 }
 ```
 
@@ -24,6 +25,7 @@ such as the API URL, routes or common headers can be stored statefully within th
 
 ```ts
 @Fixture
+@Constructor(HTTP)
 export class MyClient {
   constructor(private http: Http) {
     this.http
@@ -40,6 +42,7 @@ modifcations happen in this new contex and do not mutate the shared client.
 
 ```ts
 @Fixture
+@Constructor(HTTP)
 export class MyClient {
   constructor(private http: Http) {
     this.http
@@ -259,4 +262,36 @@ Scenario: some scenario
     And I examine product 2
     * the product name is 'alice'
     * the product price is 20
+```
+
+## Additional options
+
+Your underlying HTTPClient implementation might not handle Certain
+things the way you want, like how it parses param queries.
+
+We can set additional options on the client to change this behaviour.
+As the default client uses Axios, we can set the `paramsSerializer` option using
+the `qs` query string library
+
+```ts
+// utils.ts
+import qs from "qs";
+export const AxiosSerializer: AxiosRequestConfig = {
+  paramsSerializer: (params) => {
+    return qs.stringify(params, { arrayFormat: "comma" });
+  },
+};
+
+// my-client.ts
+
+@Fixture
+export class MyClient {
+  constructor(private http: Http) {
+    this.http
+      .url("https://api.example.com")
+      .sharedRoute("v2")
+      .sharedHeader("x-example", "true")
+      .sharedOptions(AxiosSerializer);
+  }
+}
 ```

--- a/packages/http/src/http.ts
+++ b/packages/http/src/http.ts
@@ -182,6 +182,11 @@ export class HTTP {
     return this;
   }
 
+  sharedOptions(options: HTTPAdditionalOptions<unknown>) {
+    this.#metaConfig.options(options);
+    return this;
+  }
+
   /**
    * If set to true, all requests derived from this client will require a schema be defined
    * matching any response status code. If set to false, a schema will still be used for validation
@@ -850,7 +855,8 @@ export class HTTP {
     const request = (await builder.resolveDynamicHeaders()).build();
     const meta = this.#metaConfig.derive().build();
     await this.runOnSendHooks(meta, request);
-    const result = await this.client.request<unknown, string>(request, options);
+    const opts = { ...meta.options, ...options };
+    const result = await this.client.request<unknown, string>(request, opts);
     result.data = transformResponse(meta.allowPlainText, result.data);
     await this.runOnReceiveHooks(meta, result);
     const validated = this.#validateResponse(result, meta);

--- a/packages/http/src/request-meta.config.ts
+++ b/packages/http/src/request-meta.config.ts
@@ -1,5 +1,11 @@
 import { SchemaMap } from "./schema.map";
-import { RequestHook, ResponseHook, SchemaParser, StatusCode } from "./types";
+import {
+  HTTPAdditionalOptions,
+  RequestHook,
+  ResponseHook,
+  SchemaParser,
+  StatusCode
+} from "./types";
 
 export interface SchemaConfig {
   schemas: SchemaMap;
@@ -21,6 +27,7 @@ export class MetaConfig implements SchemaConfig, HTTPHooks {
   onSend: [string, RequestHook][] = [];
   onReceive: [string, ResponseHook<unknown>][] = [];
   throwOnServerError: boolean;
+  options: HTTPAdditionalOptions<unknown> = {};
 }
 
 export class MetaConfigBuilder {
@@ -30,7 +37,12 @@ export class MetaConfigBuilder {
   #onBeforeSend: [string, RequestHook][] = [];
   #onAfterSend: [string, ResponseHook<unknown>][] = [];
   #throwOnServerError = false;
+  #options: HTTPAdditionalOptions<unknown> = {};
 
+  options(options: HTTPAdditionalOptions<unknown>) {
+    this.#options = { options };
+    return this;
+  }
   schemaMap(map: SchemaMap) {
     this.#schemaMap = map;
     return this;
@@ -104,6 +116,8 @@ export class MetaConfigBuilder {
     config.allowPlainText = this.#allowPlainText;
     config.onSend = this.#onBeforeSend;
     config.onReceive = this.#onAfterSend;
+    config.options = this.#options;
+    config.throwOnServerError = this.#throwOnServerError;
     return config;
   }
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Adds a `sharedOptions` builder method on the HTTP client to simplify passing additional config such as
AxiosRequestConfig

* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **What is the motivation for this change?**



* **Other information**:
